### PR TITLE
Using templates crashes with a LoadStoreError

### DIFF
--- a/core/httpd-espfs.c
+++ b/core/httpd-espfs.c
@@ -218,8 +218,8 @@ static size_t getFilepath(HttpdConnData *connData, char *filepath, size_t len)
 
 	if (connData->cgiArg != &httpdCgiEx) {
 		filepath[0] = '\0';
-		if (connData->cgiArg2 != NULL) {
-			outlen = strlcpy(filepath, connData->cgiArg2, len);
+		if (connData->cgiArg != NULL) {
+			outlen = strlcpy(filepath, connData->cgiArg, len);
 			if (espFsStat(espfs, filepath, &s) == 0 && s.type == ESPFS_TYPE_FILE) {
 				return outlen;
 			}
@@ -315,7 +315,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData) {
 
 	if (connData->isConnectionClosed) {
 		//Connection aborted. Clean up.
-		((TplCallback)(connData->cgiArg))(connData, NULL, &tpd->tplArg);
+		((TplCallback)(connData->cgiArg2))(connData, NULL, &tpd->tplArg);
 		espFsClose(tpd->file);
 		free(tpd);
 		return HTTPD_CGI_DONE;
@@ -466,7 +466,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData) {
 
 						tpd->chunk_resume = false;
 
-						CgiStatus status = ((TplCallback)(connData->cgiArg))(connData, tpd->token, &tpd->tplArg);
+						CgiStatus status = ((TplCallback)(connData->cgiArg2))(connData, tpd->token, &tpd->tplArg);
 						if (status == HTTPD_CGI_MORE) {
 //							espfs_dbg("Multi-part tpl subst, saving parser state");
 							// wants to send more in this token's place.....
@@ -521,7 +521,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiEspFsTemplate(HttpdConnData *connData) {
 	if (sp!=0) httpdSend(connData, e, sp);
 	if (len!=FILE_CHUNK_LEN) {
 		//We're done.
-		((TplCallback)(connData->cgiArg))(connData, NULL, &tpd->tplArg);
+		((TplCallback)(connData->cgiArg2))(connData, NULL, &tpd->tplArg);
 		ESP_LOGD(TAG, "Template sent");
 		espFsClose(tpd->file);
 		free(tpd);

--- a/core/httpd-espfs.c
+++ b/core/httpd-espfs.c
@@ -218,8 +218,8 @@ static size_t getFilepath(HttpdConnData *connData, char *filepath, size_t len)
 
 	if (connData->cgiArg != &httpdCgiEx) {
 		filepath[0] = '\0';
-		if (connData->cgiArg != NULL) {
-			outlen = strlcpy(filepath, connData->cgiArg, len);
+		if (connData->cgiArg2 != NULL) {
+			outlen = strlcpy(filepath, connData->cgiArg2, len);
 			if (espFsStat(espfs, filepath, &s) == 0 && s.type == ESPFS_TYPE_FILE) {
 				return outlen;
 			}

--- a/include/libesphttpd/route.h
+++ b/include/libesphttpd/route.h
@@ -23,10 +23,10 @@
 #define ROUTE_FILE_EX(path, ex)                    ROUTE_CGI_EX((path), cgiEspFsHook, (HttpdCgiExArg*)(ex))
 
 /** Static file as a template with a replacer function */
-#define ROUTE_TPL(path, replacer)                  ROUTE_CGI_ARG((path), cgiEspFsTemplate, (TplCallback)(replacer))
+#define ROUTE_TPL(path, replacer)                  ROUTE_CGI_ARG2((path), cgiEspFsTemplate, NULL, (TplCallback)(replacer))
 
 /** Static file as a template with a replacer function, taking additional argument connData->cgiArg2 */
-#define ROUTE_TPL_FILE(path, replacer, filepath)   ROUTE_CGI_ARG2((path), cgiEspFsTemplate, (TplCallback)(replacer), (filepath))
+#define ROUTE_TPL_FILE(path, replacer, filepath)   ROUTE_CGI_ARG2((path), cgiEspFsTemplate, (const char*)(filepath), (TplCallback)(replacer))
 
 /** Redirect to some URL */
 #define ROUTE_REDIRECT(path, target)               ROUTE_CGI_ARG((path), cgiRedirect, (const char*)(target))
@@ -38,6 +38,6 @@
 #define ROUTE_WS(path, callback)                   ROUTE_CGI_ARG((path), cgiWebsocket, (WsConnectedCb)(callback))
 
 /** Catch-all filesystem route */
-#define ROUTE_FILESYSTEM()                             ROUTE_CGI("*", cgiEspFsHook)
+#define ROUTE_FILESYSTEM()                         ROUTE_CGI("*", cgiEspFsHook)
 
 #define ROUTE_END() {NULL, NULL, NULL, NULL}


### PR DESCRIPTION
It looks like getFilepath should be using cgiArg2 for its filename, not cgiArg. This was causing getFilepath to try to read the replacer function as if it was a string, if i tried to load a page using templates in my browser.